### PR TITLE
Move login controls to sidebar

### DIFF
--- a/app.py
+++ b/app.py
@@ -191,10 +191,11 @@ initial_title = client.storage.get_chat_title(cid)
 if initial_title:
     title_ph.markdown(f"## {initial_title}")
 
-# --- Top right login/register controls ---
-top_right = st.empty()
-with top_right:
-    st.markdown("<div class='top-right'>", unsafe_allow_html=True)
+# --- Layout: chat on left, placeholder column on right ---
+left_col, right_col = st.columns([4, 1])
+
+# --- Login/Register controls at top of sidebar ---
+with st.sidebar:
     if st.session_state.user:
         st.write(f"Logged in as {st.session_state.user}")
         if st.button("Logout", key="logout_btn"):
@@ -205,7 +206,6 @@ with top_right:
             st.session_state.show_login = True
         if st.button("Make Account", key="register_btn"):
             st.session_state.show_register = True
-    st.markdown("</div>", unsafe_allow_html=True)
 
 st.sidebar.markdown("---")
 st.sidebar.markdown("<p style='text-align:center; font-size: 32px;'>\U0001F464</p>", unsafe_allow_html=True)
@@ -223,7 +223,12 @@ if st.session_state.show_login:
                 st.experimental_rerun()
             else:
                 st.error("Invalid credentials")
-        oauth_res = google_oauth.authorize_button("Login with Google", key="google_login")
+        oauth_res = google_oauth.authorize_button(
+            "Login with Google",
+            redirect_uri=GOOGLE_REDIRECT_URI,
+            scope=GOOGLE_SCOPE,
+            key="google_login",
+        )
         if oauth_res and "token" in oauth_res:
             token = oauth_res.get("token")
             headers = {"Authorization": f"Bearer {token['access_token']}"}
@@ -245,18 +250,19 @@ if st.session_state.show_register:
         reg_email = st.text_input("Email", key="reg_email_main")
         reg_pw = st.text_input("Password", type="password", key="reg_pw_main")
         if st.button("Register", key="register_submit"):
-            if "@" in reg_email and auth.create_user(reg_email, reg_pw):
+            if "@" not in reg_email:
+                st.error("Please enter a valid email")
+            elif auth.user_exists(reg_email):
+                st.error("User already exists")
+            elif auth.create_user(reg_email, reg_pw):
                 st.success("Account created")
                 st.session_state.show_register = False
             else:
-                st.error("User exists")
+                st.error("Could not create account")
         if st.button("Back to login", key="switch_to_login"):
             st.session_state.show_register = False
             st.session_state.show_login = True
         st.markdown("</div>", unsafe_allow_html=True)
-
-# --- 6. Create two columns: chat on left, blank placeholder on right ---
-left_col, right_col = st.columns([4, 1])
 
 # Use a container inside the left column for chat history
 chat_container = left_col.container()
@@ -278,7 +284,7 @@ def draw_history():
             else:
                 render_bubble(text, role)
 
-if history:
+if history and not (st.session_state.show_login or st.session_state.show_register):
     draw_history()
 
 # --- 7. Input form & streaming ---


### PR DESCRIPTION
## Summary
- move login/register buttons into sidebar
- show clearer errors when registering
- hide chat history while login or register overlays are open

## Testing
- `python -m py_compile app.py auth.py client.py storage.py`


------
https://chatgpt.com/codex/tasks/task_e_68420d0475c083259fc60a19b77953fc